### PR TITLE
fix import error for different pip versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ try:
 except ImportError:
     from distutils.core import setup, find_packages
 
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
On some systems, such as Ubuntu 16.04 (the current most recent Ubuntu environment for Travis CI), pip does not have a `pip.req` module available, which is required for the setup script for this module to install. I've put in a try/except so that the function `parse_requirements` can be imported so this module can be installed.